### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/shmatov/jshint-jsx",
   "dependencies": {
-    "jshint": "2.4.x",
+    "jshint": "^2.5.8",
     "lodash": "^2.4.1",
-    "react-tools": "^0.10.0"
+    "react-tools": "^0.12.0"
   }
 }


### PR DESCRIPTION
bump `jshint` to `^2.5.8`
bump `react-tools` to `^0.12` (which adds support to React 0.12)

Can you release a new version?
Thanks!
