### PR TITLE
Add support for custom validation of lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ var jsxhint = (function() {
         var transformedLines = transformedCode ? transformedCode.split('\n') : [];
         var modified = transformedCode ? modifiedLines(originalLines, transformedLines) : {};
 
+        // workaround the errors array sometimes containing `null`
+        errors = _.compact(errors);
+
         jsxhint.errors = _.reject(errors, function(e) {
             var ignore = ignoreError[e.code];
 


### PR DESCRIPTION
Hi!

First of all, thank you for your work on this package!

This pull request implements the possibility of adding custom validation functions for error codes. The problem I had was with the maxlen rule, which sometimes would cause the linter to say a line was too long even though it wasn't. This was due to the fact that the transformed code is what is being linted, where as the non-transformed code is typically what I see whilst developing (and in this case, the JS line was longer than the JSX).

My solution, and hopefully you think it is a good one, is to check for a custom validation function for the given error code when the linter identifies an issue. This function takes the original line and the transformed line as parameters and should return whether or not the linter can consider the line to be valid.

Basically, it works like the code that handles rules to ignore, only instead of boolean values it contains functions which return boolean values. I thought about combining the two, but didn't as to not change too much at once.

Hope you'll consider this addition! Let me know if there's something you need me to change in order for this to be accepted.
